### PR TITLE
Fix ‘GitHub’ spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
  
 [![Chrome extension](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/lovely-forks/ialbpcipalajnakfondkflpkagbkdoib)
 
-An addon to help you notice **notable** forks of a Github project.
+An addon to help you notice **notable** forks of a GitHub project.
 
-Sometimes on Github, projects are abandoned by the original authors and the
+Sometimes on GitHub, projects are abandoned by the original authors and the
 development continues on a fork. However, the original repository is seldom
 updated to inform newcomers of that fact. I have often wasted effort on making
 a pull-request or installing old buggy versions of projects when the community
@@ -19,7 +19,7 @@ had already moved to a fork.
 To make matters worse, the old projects usually have higher search-engine
 traffic and a lot more stars than the forks. This makes the forks even harder
 to find. This addon tries to remedy that by adding a subscript under the name
-of the repository on the Github page of the project with a link to the most
+of the repository on the GitHub page of the project with a link to the most
 notable fork (i.e. the fork with the most stars and at least one star), if such
 a fork exists.
 
@@ -78,7 +78,7 @@ This project uses icons made by
 [bfred-it](https://github.com/bfred-it) has contributed to improving the look
 and feel of the extension considerably.
 
-[izuzak](https://github.com/izuzak) from Github was instrumental in helping me
+[izuzak](https://github.com/izuzak) from GitHub was instrumental in helping me
 with bug fixing and suggesting [compare API](https://developer.github.com/v3/repos/commits/#compare-two-commits) 
 for improving the heuristic to determine if a fork is more recent than the upstream
 repository.

--- a/app/data/contentscript.js
+++ b/app/data/contentscript.js
@@ -91,7 +91,7 @@ function getForksElement() {
         try {
             text = document.createElement('span');
 
-            // Stealing the styling from Github fork-info
+            // Stealing the styling from GitHub fork-info
             text.classList.add('fork-flag', 'lovely-forks-addon');
 
             repoName.appendChild(text);
@@ -104,7 +104,7 @@ function getForksElement() {
         }
     } else {
         console.warn(_logName,
-                     'Looks like the layout of the Github page has changed.');
+                     'Looks like the layout of the GitHub page has changed.');
     }
 }
 
@@ -339,7 +339,7 @@ function onreadystatechangeFactory(xhr, successFn) {
                              'Looks like the rate-limit was exceeded.');
             } else {
                 console.warn(_logName,
-                             'Github API returned status:', xhr.status);
+                             'GitHub API returned status:', xhr.status);
             }
         } else {
             // Request is still in progress
@@ -434,7 +434,7 @@ function runFor(user, repo) {
         } else {
             if (DEBUG) {
                 console.log(_logName,
-                            'Requesting the data from Github API.');
+                            'Requesting the data from GitHub API.');
             }
             makeFreshRequest(user, repo);
         }

--- a/app/lib/main.js
+++ b/app/lib/main.js
@@ -10,7 +10,7 @@ require('sdk/preferences/service').set('extensions.sdk.console.logLevel', 'debug
 var data = require('sdk/self').data;
 var { PageMod } = require('sdk/page-mod');
 
-// Work only on Github URLs
+// Work only on GitHub URLs
 var matchPatterns = [ '*.github.com' ];
 
 // Create a content script

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
     "name": "lovely-forks",
     "id": "github-forks-addon@musicallyut.in",
     "title": "Lovely forks",
-    "description": "Show notable forks of Github projects.",
+    "description": "Show notable forks of GitHub projects.",
     "author": "Utkarsh Upadhyay",
     "license": "MPL 2.0",
     "version": "2.6.1",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Lovely forks",
   "version": "2.6.1",
   "manifest_version": 2,
-  "description": "Show notable forks of Github projects.",
+  "description": "Show notable forks of GitHub projects.",
   "homepage_url": "https://github.com/musically-ut/github-forks-addon",
   "icons": {
     "128": "app/data/images/Heart_and_fork_inside_128.png"


### PR DESCRIPTION
This patch fixes the spelling of ‘GitHub’ from ‘Github’.