### PR TITLE
added brower_action, default_icon to enable icon color

### DIFF
--- a/manifest.template.json
+++ b/manifest.template.json
@@ -7,6 +7,9 @@
   "icons": {
     "128": "webext/icons/Heart_and_fork_inside_128.png"
   },
+  "browser_action": {
+    "default_icon": "webext/icons/Heart_and_fork_inside_128.png"
+  },
   "web_accessible_resources": [
     "webext/icons/star.svg",
     "webext/icons/flame.svg"


### PR DESCRIPTION
Adding default_icon in browser_action should show icon color. 
Haven't got the chance to test out because the build tools are for Linux. 
Let me know if it works fine. Thanks! 😄