### PR TITLE
Fix multiple "also forked" elements

### DIFF
--- a/webext/data/contentscript.js
+++ b/webext/data/contentscript.js
@@ -168,6 +168,7 @@ function safeUpdateDOM (action, actionName) {
 }
 
 function showDetails (fullName, url, numStars, remoteIsNewer, indented) {
+  if (text.parentNode.classList.contains('has-lovely-forks')) return
   const forkA = document.createElement('a')
   forkA.href = url
   forkA.append(fullName)


### PR DESCRIPTION
This is a quick fix that checks for the `has-lovely-forks` class and aborts adding a new one if it exists. Fixes #64

Looking at the code it seems the issue stems from the `getForksElement` function not actually finding the previous element even if it exists (see code snippet below). Though my fix is implemented in the `showDetails` function.

```js
// This if-statement never seems to return true
if (document.body.contains(text)) {
    return text
}
```
