### PR TITLE
Implement skip repos option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{html,js,css}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -119,3 +119,5 @@ repository.
 [olso](https://github.com/olso) added an option to set how many days old the last commit on the current repository should be before the forks are shown.
 
 [Jorgen1040](https://github.com/Jorgen1040) helped fix a bug about multiple "also forked" messages appearing.
+
+[francislavoie](https://github.com/francislavoie) implemented a [repo skip list](https://github.com/musically-ut/lovely-forks/pull/74), to not show forks on specific repos.

--- a/webext/data/contentscript.js
+++ b/webext/data/contentscript.js
@@ -3,6 +3,7 @@
 
 const _logName = 'lovely-forks:'
 const STAR_THRES_KEY = 'STAR_THRES_KEY'
+const SKIP_REPOS_KEY = 'SKIP_REPOS_KEY'
 const INDENT_KEY = 'INDENT_KEY'
 const LF_PREF_KEY = 'LF_PREF_KEY'
 const DAYS_THRES_KEY = 'DAYS_THRES_KEY'
@@ -20,6 +21,7 @@ function getPreferences () {
       x = x[LF_PREF_KEY] || {}
 
       pref[STAR_THRES_KEY] = x[STAR_THRES_KEY] || 1
+      pref[SKIP_REPOS_KEY] = x[SKIP_REPOS_KEY] || ""
       pref[DAYS_THRES_KEY] = x[DAYS_THRES_KEY] || 0
       pref[INDENT_KEY] = x[INDENT_KEY] || false
 
@@ -218,6 +220,13 @@ function isQuotaExceeded (e) {
 function processWithData (user, repo, remoteDataStr,
   selfDataStr, isFreshData, pref) {
   try {
+    /* Skip displaying if the repo is in the skip list */
+    const skipRepos = pref[SKIP_REPOS_KEY].split(/[\s\n,]+/)
+    const inSkipList = skipRepos.some(val => val.indexOf(user + "/" + repo) > -1)
+    if (inSkipList) {
+      return
+    }
+
     /* Parse fork data */
     /* Can either be just one data element,
          * or could be the list of all forks. */

--- a/webext/options_ui/js/main.js
+++ b/webext/options_ui/js/main.js
@@ -3,6 +3,7 @@
 
 const DEBUG = false
 const STAR_THRES_KEY = 'STAR_THRES_KEY'
+const SKIP_REPOS_KEY = 'SKIP_REPOS_KEY'
 const INDENT_KEY = 'INDENT_KEY'
 const LF_PREF_KEY = 'LF_PREF_KEY'
 const DAYS_THRES_KEY = 'DAYS_THRES_KEY'
@@ -10,20 +11,24 @@ const DAYS_THRES_KEY = 'DAYS_THRES_KEY'
 chrome.storage.local.get(LF_PREF_KEY, x => {
   x = x[LF_PREF_KEY] || {}
   const thres = x[STAR_THRES_KEY] || 1
+  const skipRepos = x[SKIP_REPOS_KEY] || ""
   const dayThres = x[DAYS_THRES_KEY] || 0
   const indent = x[INDENT_KEY] || false
   $('.js-star-threshold').val(thres)
+  $('.js-skip-repos').val(skipRepos)
   $('.js-days-threshold').val(dayThres)
   $('.js-to-indent').checkbox(indent ? 'set checked' : 'set unchecked')
 })
 
 function savePref () {
   const thres = $('.js-star-threshold').val() || 0
+  const skipRepos = $('.js-skip-repos').val() || ""
   const dayThres = $('.js-days-threshold').val() || 0
   const indent = $('.js-to-indent').checkbox('is checked') || false
   const pref = {
     [INDENT_KEY]: indent,
     [STAR_THRES_KEY]: thres,
+    [SKIP_REPOS_KEY]: skipRepos,
     [DAYS_THRES_KEY]: dayThres
   }
   chrome.storage.local.set({ [LF_PREF_KEY]: pref }, () => {
@@ -39,4 +44,5 @@ function savePref () {
 
 $('.js-to-indent.ui.checkbox').checkbox({ onChange: savePref })
 $('.js-star-threshold').on('change', savePref)
+$('.js-skip-repos').on('change', savePref)
 $('.js-days-threshold').on('change', savePref)

--- a/webext/options_ui/options.html
+++ b/webext/options_ui/options.html
@@ -31,26 +31,25 @@
     </section>
 
     <section class="ui settings basic segment">
-        <p>Only show message when last commit in base repo is older than?</p>
-        <div class="ui form">
-            <div class="ui field">
-                <div class="ui labeled input">
-                    <div class="ui label">Days:</div>
-                    <input id="days_threshold" class="js-days-threshold" type="number" min="0">
-                </div>
-            </div>
+      <p>Only show message when last commit in base repo is older than?</p>
+      <div class="ui form">
+        <div class="ui field">
+          <div class="ui labeled input">
+            <div class="ui label">Days:</div>
+            <input id="days_threshold" class="js-days-threshold" type="number" min="0">
+          </div>
         </div>
+      </div>
     </section>
 
     <section class="ui settings basic segment">
       <p>Should the message under the repository name be <span class="emph">indented?</span></p>
       <div class="ui form centered-field">
-          <span class="ui right aligned basic label">do not indent</span>
-          <div class="ui fitted toggle checkbox js-to-indent to-indent">
-            <input id="to_indent" type="checkbox">
-          </div>
-          <span  class="ui left aligned basic label">indent</span>
+        <span class="ui right aligned basic label">do not indent</span>
+        <div class="ui fitted toggle checkbox js-to-indent to-indent">
+          <input id="to_indent" type="checkbox">
         </div>
+        <span class="ui left aligned basic label">indent</span>
       </div>
     </section>
 

--- a/webext/options_ui/options.html
+++ b/webext/options_ui/options.html
@@ -31,6 +31,16 @@
     </section>
 
     <section class="ui settings basic segment">
+      <p>Repos on which to skip showing forks (comma, space, or newline separated list)</p>
+      <div class="ui form">
+        <div class="ui field">
+          <label for="skip_repos">Repos to skip:</label>
+          <textarea id="skip_repos" class="js-skip-repos">
+        </div>
+      </div>
+    </section>
+
+    <section class="ui settings basic segment">
       <p>Only show message when last commit in base repo is older than?</p>
       <div class="ui form">
         <div class="ui field">


### PR DESCRIPTION
Fixes #73, specifically the first suggestion there.

I didn't actually test this. Just made the code changes. I don't super feel like playing with the build tooling right now, sorry 😅

- I updated the `.editorconfig` because it was misaligned with what the files in the project were actually wanting.
- Removed an orphan `</div>` which didn't have an opener anymore, unindented.
- Unindented a 4-space indented block of HTML.

Let me know if you want me to drop these changes, I kept them in a separate commit just in case.

---

- Add `SKIP_REPOS_KEY` to the prefs storage, simple string from a textarea input.
- Using `.split(/[\s\n,]+/)` to turn the options into an array. This allows for repos to be separated by comma, space, or newline. So something like `"foo    bar,,baz\n\nfoobar"` turns into `["foo", "bar", "baz", "foobar"]` which is pretty clean.
- Using `.some` to find if any of the skipped repos contain the string `user + "/" + repo`. So for example if the skip list has `https://github.com/foo/foo, https://github.com/bar/bar`, then it should return true for `foo/foo` and `bar/bar` as the user/repo and return false for `baz/baz`.
- Simply returns to avoid showing the UI. Following the lead of the `starGazers` part which does a simple `return`.
- Doing this as early as possible to avoid doing extra work with JSON parsing etc if it should be skipped.

Hopefully this all makes sense. Hopefully I got the HTML to look right (took a quick peek at semantic-ui docs, never used it before).