### PR TITLE
Fix `also forked` disappearing

### DIFF
--- a/webext/data/contentscript.js
+++ b/webext/data/contentscript.js
@@ -170,7 +170,6 @@ function safeUpdateDOM (action, actionName) {
 }
 
 function showDetails (fullName, url, numStars, remoteIsNewer, indented) {
-  if (text.parentNode.classList.contains('has-lovely-forks')) return
   const forkA = document.createElement('a')
   forkA.href = url
   forkA.append(fullName)


### PR DESCRIPTION
Recently noticed that the "also forked" message has been disappearing when switching between different repo views (Issues, Pull requests, etc). 

It seems GitHub has changed the way they load/render the page since the fix I implemented in #69 now pretty much does the opposite (detects it when it doesn't exist, thus doesn't add it). So just removing it fixes the issue.
Hopefully it doesn't reintroduce the old bug, but I haven't been able to reproduce it yet, *fingers crossed*.